### PR TITLE
Fix dependencies in rockspec

### DIFF
--- a/rockspecs/lgmp-1.0-1.rockspec
+++ b/rockspecs/lgmp-1.0-1.rockspec
@@ -15,7 +15,7 @@ https://gmplib.org/
 }
 
 dependencies = {
-  "lua >= 5.1, < 5.4"
+  "lua >= 5.2, < 5.5"
 }
 
 external_dependencies = {
@@ -30,7 +30,9 @@ build = {
     gmp = "gmp.lua",
     ["c-gmp"] = {
       sources = {"lgmp.c"},
-      libraries = {"gmp"}
+      libraries = {"gmp"},
+      incdirs = {"$(GMP_INCDIR)"},
+      libdirs = {"$(GMP_LIBDIR)"},
     }
   }
 }


### PR DESCRIPTION
The current rockspec for 1.0 is incorrect in two respects:

- It declares compatibility with 5.1, while in reality the Lua part is not compatible (because it uses `_ENV`) even though the C part is;
- It does not respect the values of any `GMP_*DIR` variables that might have been passed to `luarocks`.

This is my attempt at an updated rockspec. It also declares compatibility with 5.4 (which did not exist when you released the original rockspec) because as far as I can tell the extension builds and runs on it out of the box.

Unfortunately, it seems like a new rockspec revision does not override the older ones, so if there is a 1.0-1 rockspec which mistakenly declares 5.1 compatibility and a 1.0-2 one that does not, Luarocks on 5.1 will just pick up 1.0-1 as if nothing were wrong. The only way out seems to be to overwrite the existing revision (which Luarocks technically permits, if only as an exceptional measure), so my patch changes the existing rockspec in place (assuming you are going to upload it on top of the old one). I’m not sure if this is the best solution.