### PR TITLE
Fix 5.1 compatibility

### DIFF
--- a/gmp.lua
+++ b/gmp.lua
@@ -23,6 +23,7 @@ local tostring = tostring
 local tonumber = tonumber
 
 local _ENV = {}
+if setfenv then setfenv(1, _ENV) end
 
 local prv = {}
 local aux = {}


### PR DESCRIPTION
While the C part of the library builds and works fine on Lua 5.1 (and LuaJIT), previously, importing the Lua part there with `require 'gmp'` returned an empty table because of the lack of `_ENV` there. This is a very simple fix for that problem.

In principle, you could take the rockspec from #1, expand the version requirement to include 5.1, release it as 1.1-1 or similar, and `luarocks install lgmp` would yield a working install on any Lua version. The only advantage of additionally overwriting 1.0-1 as suggested there would be that `luarocks install lgmp 1.0` would then correctly fail on 5.1.